### PR TITLE
fix: neotree not display dir with "git" in name

### DIFF
--- a/lua/doom/modules/features/explorer/init.lua
+++ b/lua/doom/modules/features/explorer/init.lua
@@ -22,7 +22,7 @@ explorer.settings = {
     },
   },
   filters = {
-    custom = { ".git", "node_modules.editor", ".cache", "__pycache__" },
+    custom = { "^\\.git", "node_modules.editor", "^\\.cache", "__pycache__" },
   },
   renderer = {
     indent_markers = {


### PR DESCRIPTION
I have a folder with "git" in name (git-tools), and I have no way to have it displayed. 
Dive into code, and likely the filter regex is incorrect. 