### PR TITLE
fix: nvim-tree broken when lsp disabled

### DIFF
--- a/lua/doom/modules/features/explorer/init.lua
+++ b/lua/doom/modules/features/explorer/init.lua
@@ -114,7 +114,7 @@ explorer.configs["nvim-tree.lua"] = function()
 
   local tree_cb = require("nvim-tree.config").nvim_tree_callback
 
-  local override_table
+  local override_table = {}
   if is_module_enabled("features", "lsp") then
     override_table = {
       diagnostics = {


### PR DESCRIPTION
When "LSP" module is disabled and "explorer" module enabled, everytime when nvimtree was being loaded, error occurs in  tbl_deep_extend for nvim config because of uninitialized variable

