### PR TITLE
Fixed Terminal not opening via hotkey

### DIFF
--- a/lua/doom/modules/features/terminal/init.lua
+++ b/lua/doom/modules/features/terminal/init.lua
@@ -27,6 +27,7 @@ terminal.packages = {
     "akinsho/toggleterm.nvim",
     commit = "a54e6c471ce1cd8ef8357e34598a28a955297131",
     cmd = { "ToggleTerm", "TermExec" },
+    keys = {terminal.settings.open_mapping},
     lazy = true,
   },
 }


### PR DESCRIPTION
The key to open the terminal, F4 by default, is not listed in the hotkeys that cause lazy.nvim to load the terminal module.  As a result, the hotkey to open the terminal does not work unless the terminal module has been loaded by lazy.nvim (which, with current default configuration, only happens if the user manually enters :TermExec or :ToggleTerm)